### PR TITLE
fix for 'withotSpecialCharacters' typo to 'withoutSpecialCharacters'

### DIFF
--- a/lib/src/string_extension.dart
+++ b/lib/src/string_extension.dart
@@ -22,7 +22,7 @@ extension StringValidatorExtension on String? {
   bool get isValidEmail => this != null ? RegExp(RegexConstans.instance.emailRegex).hasMatch(this!) : false;
   bool get isValidPassword => this != null ? RegExp(RegexConstans.instance.passwordRegex).hasMatch(this!) : false;
 
-  String? get withotSpecialCharacters {
+  String? get withoutSpecialCharacters {
     return isNullOrEmpty ? this : removeDiacritics(this!);
   }
 }

--- a/test/extension/string_extension_test.dart
+++ b/test/extension/string_extension_test.dart
@@ -9,7 +9,7 @@ void main() {
   });
 
   test('Remove special characters - çamur', () {
-    var correctText = 'çamur'.withotSpecialCharacters;
+    var correctText = 'çamur'.withoutSpecialCharacters;
     expect(correctText, 'camur');
   });
 }


### PR DESCRIPTION
fix for 'withotSpecialCharacters' typo to 'withoutSpecialCharacters'