### PR TITLE
chore: add 4.3.0 changelog entry and bump version to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # [4.3.0]
-- Migrated web support from dart:html to package:web, the package now builds with wasm
-- Renamed FileType and SlideType enum values to lowercase (breaking, e.g. FileType.IMAGE -> FileType.image, SlideType.DEFAULT -> SlideType.defaultType)
-- Updated share extension to the new SharePlus API
-- Catch blocks now use on Exception instead of catching everything
+- Migrated web support from `dart:html` to `package:web`; the package now builds with WASM
+- Renamed `FileType` and `SlideType` enum values to lowercase (breaking, e.g. `FileType.IMAGE` -> `FileType.image`, `SlideType.DEFAULT` -> `SlideType.defaultType`)
+- Updated share extension to the new `SharePlus` API
+- Catch blocks now use `on Exception` instead of catching everything
 - Raised minimum Flutter version to 3.19.0
 - Updated README with a full overview of extensions and utilities
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [4.3.0]
+- Migrated web support from dart:html to package:web, the package now builds with wasm
+- Renamed FileType and SlideType enum values to lowercase (breaking, e.g. FileType.IMAGE -> FileType.image, SlideType.DEFAULT -> SlideType.defaultType)
+- Updated share extension to the new SharePlus API
+- Catch blocks now use on Exception instead of catching everything
+- Raised minimum Flutter version to 3.19.0
+- Updated README with a full overview of extensions and utilities
+
 # [4.0.0]
 - Added web support for all extension
 - Updated documentation for general

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kartal
 description: Kartal is an extension package for easy to use at app development
   time. You can access more features with primitive variables(context, string
   etc.).
-version: 4.3.0-dev.1
+version: 4.3.0
 issue_tracker: https://github.com/vb10/kartal/issues
 repository: https://github.com/VB10/kartal
 screenshots:


### PR DESCRIPTION
Prepares release/4.3.0 (#87) for a stable release:

- `CHANGELOG.md`: adds the missing `# [4.3.0]` entry, written from the actual branch diff against master
- `pubspec.yaml`: `4.3.0-dev.1` -> `4.3.0`

4.1.0 and 4.2.0 entries are missing as well; kept this PR to the 4.3.0 release only, can backfill those separately if wanted.
