### PR TITLE
fix: make hideLoader safe when no loader is showing

### DIFF
--- a/lib/src/utility/popup_manager/popup_manager.dart
+++ b/lib/src/utility/popup_manager/popup_manager.dart
@@ -63,14 +63,16 @@ final class PopupManager {
   /// is safe to call from cleanup paths such as `finally` blocks.
   void hideLoader({String? id}) {
     assert(_state != null, 'Tried to hide loader but navigatorState was null.');
+    final state = _state;
+    if (state == null) return;
 
     if (id == null) {
       if (_routes.isEmpty) return;
-      _state!.removeRoute(_routes.removeLast());
+      state.removeRoute(_routes.removeLast());
       return;
     }
     final routeIndex = _routes.indexWhere((element) => element.id == id);
     if (routeIndex == -1) return;
-    _state!.removeRoute(_routes.removeAt(routeIndex));
+    state.removeRoute(_routes.removeAt(routeIndex));
   }
 }

--- a/lib/src/utility/popup_manager/popup_manager.dart
+++ b/lib/src/utility/popup_manager/popup_manager.dart
@@ -58,18 +58,19 @@ final class PopupManager {
 
   /// If [id] is provided closes loader with given [id]
   /// If not closes latest shown loader
+  ///
+  /// Does nothing when no loader is showing or no loader matches [id], so it
+  /// is safe to call from cleanup paths such as `finally` blocks.
   void hideLoader({String? id}) {
-    assert(
-      id == null || _routes.where((element) => element.id == id).isNotEmpty,
-      'Tried to close loader with id: $id which does not exist',
-    );
     assert(_state != null, 'Tried to hide loader but navigatorState was null.');
 
     if (id == null) {
+      if (_routes.isEmpty) return;
       _state!.removeRoute(_routes.removeLast());
       return;
     }
     final routeIndex = _routes.indexWhere((element) => element.id == id);
+    if (routeIndex == -1) return;
     _state!.removeRoute(_routes.removeAt(routeIndex));
   }
 }

--- a/test/extension/popup_manager_extension_test.dart
+++ b/test/extension/popup_manager_extension_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kartal/kartal.dart';
+import 'package:kartal/src/utility/popup_manager/popup_manager.dart';
 
 void main() {
   testWidgets(
@@ -21,6 +22,61 @@ void main() {
       await tester.pump();
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       await tester.pump(const Duration(milliseconds: 2500));
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'hideLoader without a showing loader does nothing',
+    (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navigatorKey, home: const Scaffold()),
+      );
+
+      PopupManager(navigatorKey).hideLoader();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'hideLoader is safe to call twice for the same loader',
+    (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navigatorKey, home: const Scaffold()),
+      );
+      final manager = PopupManager(navigatorKey)..showLoader();
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      manager.hideLoader();
+      await tester.pumpAndSettle();
+      manager.hideLoader();
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'hideLoader with an unknown id keeps the current loader',
+    (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(navigatorKey: navigatorKey, home: const Scaffold()),
+      );
+      final manager = PopupManager(navigatorKey)..showLoader(id: 'upload');
+      await tester.pump();
+
+      manager.hideLoader(id: 'download');
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      manager.hideLoader(id: 'upload');
+      await tester.pumpAndSettle();
       expect(find.byType(CircularProgressIndicator), findsNothing);
     },
   );


### PR DESCRIPTION
**Problem:** `PopupManager.hideLoader()` crashes when there is no loader to close:

- `hideLoader()` with nothing showing throws `RangeError (length): Invalid value: Valid value range is empty: -1` in every build mode - the existing assert only covers the `id != null` case, so `_routes.removeLast()` runs on an empty list. The typical way to hit this is a cleanup path (for example a `finally` block) that hides after the loader was already closed.
- `hideLoader(id: ...)` with an id that is not showing passes `indexWhere`'s `-1` straight into `removeAt`. The assert catches this in debug, but asserts are stripped in release builds, so production apps get the same `RangeError`.

**Solution:** Treat "nothing to close" as a no-op: return early when `_routes` is empty or no route matches `id`. This is also where the #63 review discussion was heading with the `routeIndex` check. The misuse assert is removed so debug and release behave the same; hiding with an unknown id now does nothing instead of tripping an assert in debug. The `_state != null` assert stays - a null navigator is a setup error, not a runtime race.

Three regression tests cover the empty, double-hide and unknown-id paths.
