### PR TITLE
fix: stop the share sheet from opening twice on iPad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Updated readme file for utility and some other extension
 - Fixed open maps issue for android side.
 
+## [4.3.0]
+- Fixed the share sheet opening twice on iPad, the iPad branch no longer falls through to the second share call
+- Widened the share_plus constraint to `>=11.0.0 <14.0.0` so apps can pick up the iOS 26 share crash fix released in share_plus 12.0.1
+
 ## [4.2.0]
 - Added new color extension for random color and with opacity
 - Updated readme file for new version

--- a/lib/src/private/platform/app_platform.dart
+++ b/lib/src/private/platform/app_platform.dart
@@ -70,6 +70,7 @@ final class AppPlatform implements CustomPlatform {
           value ?? '',
           sharePositionOrigin: _deviceUtils.ipadPaddingBottom,
         );
+        return;
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: kartal
 description: Kartal is an extension package for easy to use at app development
   time. You can access more features with primitive variables(context, string
   etc.).
-version: 4.2.0
+version: 4.3.0
 issue_tracker: https://github.com/vb10/kartal/issues
 repository: https://github.com/VB10/kartal
 screenshots:
@@ -25,7 +25,7 @@ dependencies:
   mask_text_input_formatter: ^2.0.0
   mime: ^2.0.0
   package_info_plus: ^8.0.2
-  share_plus: ^11.0.0
+  share_plus: ">=11.0.0 <14.0.0"
   url_launcher: ^6.1.5
 
 dev_dependencies:


### PR DESCRIPTION
## Problem

`AppPlatform.share()` has no early return after the iPad branch:

```dart
Future<void> share(String? value) async {
  if (io.Platform.isIOS) {
    final isAppIpad = await _deviceUtils.isIpad();
    if (isAppIpad) {
      await Share.share(value ?? '', sharePositionOrigin: _deviceUtils.ipadPaddingBottom);
    }
  }

  await Share.share(value ?? '');   // runs on iPad too
}
```

On iPad the share sheet is presented twice — the second call goes out without `sharePositionOrigin`.

That second call is also where iOS 26 breaks. share_plus below 12.0.1 raises `sharePositionOrigin: argument must be set` whenever a popover presentation controller exists, and since Xcode 26 that is true on iPhone as well, not just iPad. So on iOS 26 the origin-less call throws on every device.

## Changes

**1. Added the missing `return`** — the iPad branch no longer falls through.

**2. Widened the share_plus constraint** to `>=11.0.0 <14.0.0`.

The iPhone false positive is fixed upstream in [share_plus 12.0.1](https://github.com/fluttercommunity/plus_plugins/pull/3699), but `^11.0.0` pins consumers below it. A range rather than `^12.0.0` keeps this non-breaking: apps still on 11.x are unaffected, and apps that need the fix can move up without waiting for another kartal release.

The deprecated `Share` API is still present in 13.x, so no call sites change.

Bumped to `4.3.0` — no API change, so a minor release.

## Verification

- `flutter analyze` — 0 errors/warnings, same issue count as master (40)
- `flutter test` — 92 tests pass
- `flutter pub get` resolves cleanly; picks 12.0.2 (pub does not take the major jump on its own, which is the intent — nobody is forced to 13.x)

## Not included

`Share` is deprecated in favour of `SharePlus.instance.share(ShareParams(...))`. Migrating would touch `share`, `shareMail`, `shareWhatsApp` and `StringShareMixin`, so I left it out of this fix. Happy to open a separate PR if you want it.