### PR TITLE
chore(example): name the demo gallery in its web metadata

### DIFF
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Live demo gallery for kartal, a Flutter extension package for context, string, num, colour, collection and validator helpers.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
+  <meta name="apple-mobile-web-app-title" content="kartal">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>example</title>
+  <title>kartal — demo gallery</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/example/web/manifest.json
+++ b/example/web/manifest.json
@@ -1,12 +1,12 @@
 {
-    "name": "example",
-    "short_name": "example",
+    "name": "kartal — demo gallery",
+    "short_name": "kartal",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",
     "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
-    "orientation": "portrait-primary",
+    "description": "Live demo gallery for kartal, a Flutter extension package for context, string, num, colour, collection and validator helpers.",
+    "orientation": "any",
     "prefer_related_applications": false,
     "icons": [
         {


### PR DESCRIPTION
The demo gallery is live at <https://vb10.github.io/kartal/>, but its web shell
was still the untouched `flutter create` template.

| | Before | After |
| --- | --- | --- |
| `<title>` | `example` | `kartal — demo gallery` |
| `meta description` | `A new Flutter project.` | describes the package |
| `apple-mobile-web-app-title` | `example` | `kartal` |
| `manifest.name` / `short_name` | `example` | `kartal — demo gallery` / `kartal` |
| `manifest.orientation` | `portrait-primary` | `any` |

The orientation change is the only one that is not purely cosmetic: the gallery
exists to demonstrate `context.device.responsive()`, and an installed PWA locked
to portrait can never reach the rail or extended-rail layouts.

## Scope

Demo only. `example/web/` is excluded from the published archive via
`.pubignore`, so the package on pub.dev is unaffected and this does not need to
land before the `v5.0.0` tag.

## Verified

`flutter build web --release --base-href /kartal/` on Flutter 3.44.8 locally,
then confirmed the generated output:

- `build/web/index.html` → `<title>kartal — demo gallery</title>`
- `build/web/manifest.json` → `name: kartal — demo gallery`
- `serviceWorkerVersion` is still injected by the build, so the legacy web
  shell keeps working as it did

CI builds the same target on the pinned 3.38.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)